### PR TITLE
omx_core: fix heap corruption when unregistering component

### DIFF
--- a/exynos/multimedia/openmax/core/SEC_OMX_Component_Register.c
+++ b/exynos/multimedia/openmax/core/SEC_OMX_Component_Register.c
@@ -141,8 +141,10 @@ OMX_ERRORTYPE SEC_OMX_Component_Unregister(SEC_OMX_COMPONENT_REGLIST *componentL
 {
     OMX_ERRORTYPE ret = OMX_ErrorNone;
 
-    SEC_OSAL_Memset(componentList, 0, sizeof(SEC_OMX_COMPONENT_REGLIST) * MAX_OMX_COMPONENT_NUM);
-    SEC_OSAL_Free(componentList);
+    if (componentList != NULL) {
+        SEC_OSAL_Memset(componentList, 0, sizeof(SEC_OMX_COMPONENT_REGLIST) * MAX_OMX_COMPONENT_NUM);
+        SEC_OSAL_Free(componentList);
+    }
 
 EXIT:
     return ret;


### PR DESCRIPTION
Change-Id: I961e02c63c9873f3e4ba2f3231d2dc85264ed3c8
